### PR TITLE
Fixed iframe breaking out of message box.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,10 @@ body {
   background-color: #25ceb6;
 }
 
+iframe {
+  width: 100%;
+}
+
 .botui-app-container {
   margin-top: 40px;
 }


### PR DESCRIPTION
The `iframe`, containing the example embedded gif, has a width greater than the width of the message box and thus breaks out of the message box. Here's an example of what is happening: http://imgur.com/a/vRq7D